### PR TITLE
Fix "too few X's in template" error

### DIFF
--- a/bin/dw_push_sqlite
+++ b/bin/dw_push_sqlite
@@ -10,9 +10,9 @@ _run() {
   local -r sj_prefix="$2"
 
   local -r now_s="$(date -u +%Y%m%d%H%M%S)"
-  local -r sj_filename="$(
-    mktemp -u -t "${now_s}-XXXXXXXX-$(basename "${sqlite_file}")" | xargs basename
-  )"
+  local -r filename_prefix="$(mktemp -u -t "${now_s}-XXXXXXXX" | xargs basename)"
+  local -r sj_filename="${filename_prefix}-$(basename "${sqlite_file}")"
+
 
   echo "${sj_access_name}" \
     | xargs -t  uplink cp "${sqlite_file}" "${sj_prefix}/${sj_filename}" \


### PR DESCRIPTION
One such example:
> mktemp: too few X's in template '20210409220232-XXXXXXXX-git-events-Sgy2MXr1.db'

What's happening here is that `mktemp` thinks that the `X` in `Sgy2MXr1`
is our template (it uses the last set of `X's` for templating).

So we can just avoid using unknown input as part of the template to
prevent this from happening anymore.